### PR TITLE
Enable Dependabot in repository (#4)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+    open-pull-requests-limit: 2


### PR DESCRIPTION
In this PR you will find:

- Changes in the `dependabot.yml` for setting up the day for execution and the number of PRs that can create for package ecosystem.

Closes #4-Set up Dependabot